### PR TITLE
Update dependencies

### DIFF
--- a/Tinkoff.InvestApi/Tinkoff.InvestApi.csproj
+++ b/Tinkoff.InvestApi/Tinkoff.InvestApi.csproj
@@ -16,17 +16,16 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Google.Protobuf" Version="3.19.1"/>
-        <PackageReference Include="Grpc.Net.Client" Version="2.41.0"/>
-        <PackageReference Include="Grpc.Net.ClientFactory" Version="2.41.0"/>
-        <PackageReference Include="Grpc.Tools" Version="2.42.0">
+        <PackageReference Include="Google.Protobuf" Version="3.21.8" />
+        <PackageReference Include="Grpc.Net.Client" Version="2.49.0" />
+        <PackageReference Include="Grpc.Net.ClientFactory" Version="2.49.0" />
+        <PackageReference Include="Grpc.Tools" Version="2.50.0">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0"/>
     </ItemGroup>
 
     <ItemGroup>
-        <Protobuf Include="..\investAPI\src\docs\contracts\*.proto" Link="protos\*.proto" GrpcServices="Client"/>
+        <Protobuf Include="..\investAPI\src\docs\contracts\*.proto" Link="protos\*.proto" GrpcServices="Client" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
Обновил gRPC и Protobuf библиотеки до последних версий.
Удалил явную зависимость на `Microsoft.Extensions.DependencyInjection`, эта зависимость уже есть в `Grpc.Net.ClientFactory` которая так же завязана на `IServiceCollection`, только минимальная версия там 3.x, что позволяет не обновляться до 6 версии `Microsoft.Extensions.DependencyInjection` при использовании более старых версий .NET.